### PR TITLE
BDOG-1006: Avoid multiple User-Agent headers (httpVerbs implicitly adds one)

### DIFF
--- a/app/uk/gov/hmrc/helloworldupscan/connectors/UpscanInitiateConnector.scala
+++ b/app/uk/gov/hmrc/helloworldupscan/connectors/UpscanInitiateConnector.scala
@@ -74,7 +74,6 @@ object PreparedUpload {
 class UpscanInitiateConnector @Inject()(httpClient: HttpClient, appConfig: AppConfig)(implicit ec: ExecutionContext) {
 
   private val headers = Map(
-    HeaderNames.USER_AGENT   -> "upscan-acceptance-tests",
     HeaderNames.CONTENT_TYPE -> "application/json"
   )
 


### PR DESCRIPTION
Do not explicitly set a _User-Agent_ header, as httpVerbs implicitly sets one based upon the _appName_ defined in the application's configuration.

Prior to this change, two User-Agent headers were being sent: _hello-world-upscan_ and _upscan-acceptance-tests_.

With the move to **envoy**, the way in which this is handled has changed.  Envoy is concatenating the values into a single header: _hello-world-upscan,upscan-acceptance-tests_.  This is not a configured service in [upscan-app-config](https://github.com/hmrc/upscan-app-config/blob/master/development/verify.yaml) and so only the default Mime types are accepted - not the Mime types that are configured for the _hello-world-upscan_ service.