### PR TITLE
BDOG-2566: upgraded dependencies

### DIFF
--- a/app/assets/javascripts/init.js
+++ b/app/assets/javascripts/init.js
@@ -1,0 +1,1 @@
+window.GOVUKFrontend.initAll();

--- a/app/assets/stylesheets/application-ie-8.scss
+++ b/app/assets/stylesheets/application-ie-8.scss
@@ -1,0 +1,2 @@
+$govuk-is-ie8: true;
+@import "application";

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,0 +1,5 @@
+$govuk-assets-path: "/hello-world-upscan/assets/lib/govuk-frontend/govuk/assets/";
+$hmrc-assets-path: "/hello-world-upscan/assets/lib/hmrc-frontend/hmrc/";
+
+@import "lib/govuk-frontend/govuk/all";
+@import "lib/hmrc-frontend/hmrc/all";

--- a/app/uk/gov/hmrc/helloworldupscan/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/helloworldupscan/config/AppConfig.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/helloworldupscan/config/ErrorHandler.scala
+++ b/app/uk/gov/hmrc/helloworldupscan/config/ErrorHandler.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/helloworldupscan/connectors/UpscanInitiateConnector.scala
+++ b/app/uk/gov/hmrc/helloworldupscan/connectors/UpscanInitiateConnector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/helloworldupscan/controllers/UploadCallbackController.scala
+++ b/app/uk/gov/hmrc/helloworldupscan/controllers/UploadCallbackController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/helloworldupscan/controllers/UploadFormController.scala
+++ b/app/uk/gov/hmrc/helloworldupscan/controllers/UploadFormController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/helloworldupscan/model/model.scala
+++ b/app/uk/gov/hmrc/helloworldupscan/model/model.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/helloworldupscan/repository/UserSessionRepository.scala
+++ b/app/uk/gov/hmrc/helloworldupscan/repository/UserSessionRepository.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/helloworldupscan/services/InMemoryUploadProgressTracker.scala
+++ b/app/uk/gov/hmrc/helloworldupscan/services/InMemoryUploadProgressTracker.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/helloworldupscan/services/MongoBackedUploadProgressTracker.scala
+++ b/app/uk/gov/hmrc/helloworldupscan/services/MongoBackedUploadProgressTracker.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/helloworldupscan/services/UploadProgressTracker.scala
+++ b/app/uk/gov/hmrc/helloworldupscan/services/UploadProgressTracker.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/helloworldupscan/services/UpscanCallbackDispatcher.scala
+++ b/app/uk/gov/hmrc/helloworldupscan/services/UpscanCallbackDispatcher.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/helloworldupscan/utils/HttpUrlFormat.scala
+++ b/app/uk/gov/hmrc/helloworldupscan/utils/HttpUrlFormat.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/helloworldupscan/views/GovUKWrapper.scala.html
+++ b/app/uk/gov/hmrc/helloworldupscan/views/GovUKWrapper.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,92 +14,63 @@
  * limitations under the License.
  *@
 
-@import uk.gov.hmrc.helloworldupscan.config.AppConfig
-@import play.twirl.api.HtmlFormat
-@import views.html.layouts.GovUkTemplate
-@import uk.gov.hmrc.play.views.html.layouts._
-@import uk.gov.hmrc.play.views.html.helpers.ReportAProblemLink
+@import uk.gov.hmrc.govukfrontend.views.html.components._
+@import play.api.mvc.RequestHeader
 
 @this(
-        govUkTemplate: GovUkTemplate,
-        lh: Head,
-        headerNav: HeaderNav,
-        footer: Footer,
-        lhServiceInfo: ServiceInfo,
-        lhSidebar: Sidebar,
-        lhMainContentHeader: MainContentHeader,
-        lhMainContent: MainContent,
-        footerLinks: FooterLinks,
-        reportAProblemLink: ReportAProblemLink
+  govukTemplate: GovukTemplate,
+  govukHeader: GovukHeader,
+  govukFooter: GovukFooter,
+  govukBackLink: GovukBackLink
 )
 
-@(appConfig: AppConfig,
-  title: String,
-  mainClass: Option[String] = None,
-  mainDataAttributes: Option[Html] = None,
-  bodyClasses: Option[String] = None,
-  sidebar: Html = HtmlFormat.empty,
-  contentHeader: Option[Html] = None,
-  customHead: Option[Html] = None,
-  mainContent: Html = HtmlFormat.empty,
-  serviceInfoContent: Html = HtmlFormat.empty,
-  scriptElem: Option[Html] = None)(implicit messages: Messages, requestHeader: RequestHeader)
+@(
+  pageTitle: Option[String] = None,
+  headBlock: Option[Html] = None,
+  headerBlock: Option[Html] = None,
+  beforeContentBlock: Option[Html] = None,
+  footerBlock: Option[Html] = None,
+  footerItems: Seq[FooterItem] = Seq.empty,
+  bodyEndBlock: Option[Html] = None,
+  scriptsBlock: Option[Html] = None
+)(contentBlock: Html)(implicit messages: Messages, request : RequestHeader)
 
-@head = {
-    @lh(
-      linkElem = None,
-      headScripts = None)
-    <meta name="format-detection" content="telephone=no" />
-    @customHead
+@headerDefault = {
+  @headerBlock.getOrElse {
+    @govukHeader(Header(
+      homepageUrl = Some("https://www.gov.uk/"),
+      serviceName = Some(messages("service.name")),
+      serviceUrl = Some(messages("service.homePageUrl")),
+      containerClasses = None))
+  }
 }
 
-@headerNavLinks = {}
-
-@insideHeader = {
-    @headerNav(
-      navTitle = Some("hello-world-upscan"),
-      navTitleLink = None,
-      showBetaLink = false,
-      navLinks = Some(headerNavLinks))
+@footerDefault = {
+  @footerBlock.getOrElse {
+    @govukFooter(new Footer(meta = Some(Meta(items = Some(footerItems)))))
+  }
 }
 
-@afterHeader = {}
-
-@bodyEnd = {
-    @footer(
-      analyticsToken = Some(appConfig.analyticsToken),
-      analyticsHost = appConfig.analyticsHost,
-      ssoUrl = None,
-      scriptElem = scriptElem,
-      gaCalls = None)
+@bodyEndDefault = {
+  @bodyEndBlock
+  @scriptsBlock
 }
 
-@footerTop = {}
-
-@serviceInfo = {
-    @lhServiceInfo(
-      betaBanner = HtmlFormat.empty,
-      includeGridWrapper = false,
-      serviceInfoContent = Some(serviceInfoContent))
+@mainContentDefault = {
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column">
+    @contentBlock
+    </div>
+  </div>
 }
 
-@mainContentHeader = {
-    @if(contentHeader.isDefined) {
-        @lhMainContentHeader(contentHeader = contentHeader.get)
-    }
-}
-
-@getHelpForm = @{reportAProblemLink(appConfig.reportAProblemPartialUrl, appConfig.reportAProblemNonJSUrl)}
-
-@content = {
-    @lhMainContent(
-      article = mainContent,
-      mainClass = mainClass,
-      mainDataAttributes = mainDataAttributes,
-      mainContentHeader = mainContentHeader,
-      serviceInfo = serviceInfo,
-      getHelpForm = getHelpForm,
-      sidebar = sidebar)
-}
-
-@govUkTemplate(Some(title), bodyClasses)(head, bodyEnd, insideHeader, afterHeader, footerTop, Some(footerLinks()), true)(content)
+@govukTemplate(
+  htmlLang = Some(messages.lang.code),
+  pageTitle = pageTitle,
+  headBlock = headBlock,
+  headerBlock = headerDefault,
+  beforeContentBlock = beforeContentBlock,
+  footerBlock = footerDefault,
+  mainClasses = Some("govuk-main-wrapper--auto-spacing"),
+  bodyEndBlock = Some(bodyEndDefault)
+)(mainContentDefault)

--- a/app/uk/gov/hmrc/helloworldupscan/views/Head.scala.html
+++ b/app/uk/gov/hmrc/helloworldupscan/views/Head.scala.html
@@ -14,21 +14,13 @@
  * limitations under the License.
  *@
 
-@import uk.gov.hmrc.govukfrontend.views.html.components.Text
+@import views.html.helper.CSPNonce
 @import play.api.mvc.RequestHeader
 
-@this(layout: Layout)
+@this()
 
-@(
-  pageTitle: String,
-  heading  : String,
-  message  : String
-)(implicit
-  request : RequestHeader,
-  messages: Messages
-)
-
-@layout(pageTitle = Some(pageTitle)) {
-    <h1 class="govuk-heading-xl">@{Text(heading).asHtml}</h1>
-    <p class="govuk-body">@{Text(message).asHtml}</p>
-}
+@(headBlock: Option[Html] = None)(implicit request: RequestHeader)
+@headBlock
+<!--[if lte IE 8]><script @CSPNonce.attr src='@controllers.routes.Assets.versioned("javascripts/html5shiv.min.js")'></script><![endif]-->
+<!--[if lte IE 8]><link @CSPNonce.attr href='@controllers.routes.Assets.versioned("stylesheets/application-ie-8.css")' rel="stylesheet" type="text/css" /><![endif]-->
+<!--[if gt IE 8]><!--><link @CSPNonce.attr href='@controllers.routes.Assets.versioned("stylesheets/application.css")' media="all" rel="stylesheet" type="text/css" /><!--<![endif]-->

--- a/app/uk/gov/hmrc/helloworldupscan/views/Layout.scala.html
+++ b/app/uk/gov/hmrc/helloworldupscan/views/Layout.scala.html
@@ -14,21 +14,30 @@
  * limitations under the License.
  *@
 
-@import uk.gov.hmrc.govukfrontend.views.html.components.Text
+@import uk.gov.hmrc.hmrcfrontend.views.html.helpers.HmrcStandardFooter
 @import play.api.mvc.RequestHeader
 
-@this(layout: Layout)
-
+@this(
+  govukLayout       : GovUKWrapper,
+  head              : Head,
+  hmrcStandardFooter: HmrcStandardFooter,
+  scripts           : Scripts
+)
 @(
-  pageTitle: String,
-  heading  : String,
-  message  : String
+  pageTitle   : Option[String] = None,
+  headBlock   : Option[Html]   = None,
+  bodyEndBlock: Option[Html]   = None
+)(contentBlock: Html
 )(implicit
   request : RequestHeader,
   messages: Messages
 )
 
-@layout(pageTitle = Some(pageTitle)) {
-    <h1 class="govuk-heading-xl">@{Text(heading).asHtml}</h1>
-    <p class="govuk-body">@{Text(message).asHtml}</p>
-}
+@govukLayout(
+  pageTitle          = pageTitle,
+  headBlock          = Some(head(headBlock)),
+  beforeContentBlock = None,
+  footerBlock        = Some(hmrcStandardFooter()),
+  scriptsBlock       = Some(scripts()),
+  bodyEndBlock       = bodyEndBlock
+)(contentBlock)

--- a/app/uk/gov/hmrc/helloworldupscan/views/MainTemplate.scala.html
+++ b/app/uk/gov/hmrc/helloworldupscan/views/MainTemplate.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,35 +14,30 @@
  * limitations under the License.
  *@
 
-@import uk.gov.hmrc.helloworldupscan.config.AppConfig
-@import uk.gov.hmrc.play.views.html.layouts.{Article, Sidebar}
+@import uk.gov.hmrc.hmrcfrontend.views.html.helpers.HmrcStandardFooter
+@import play.api.mvc.RequestHeader
 
-@this(govUKWrapper: GovUKWrapper, sidebarLayout: Sidebar, articleLayout: Article)
-
-@(title: String,
-  sidebarLinks: Option[Html] = None,
-  contentHeader: Option[Html] = None,
-  bodyClasses: Option[String] = None,
-  mainClass: Option[String] = None,
-  scriptElem: Option[Html] = None,
-  customHead: Option[Html] = None)(mainContent: Html)(implicit messages: Messages, appConfig: AppConfig, requestHeader: RequestHeader)
-
-@serviceInfoContent = {}
-
-@sidebar = {
-    @if(sidebarLinks.isDefined) {
-        sidebarLayout(sidebarLinks.get, Some("sidebar"))
-    }
-}
-
-@govUKWrapper(appConfig = appConfig,
-               title = title,
-               mainClass = mainClass,
-               bodyClasses = bodyClasses,
-               sidebar = sidebar,
-               contentHeader = contentHeader,
-               mainContent = articleLayout(mainContent),
-               serviceInfoContent = serviceInfoContent,
-               scriptElem = scriptElem,
-               customHead = customHead
+@this(
+  govukLayout       : GovUKWrapper,
+  head              : Head,
+  hmrcStandardFooter: HmrcStandardFooter,
+  scripts           : Scripts
 )
+@(
+  title       : Option[String] = None,
+  customHead  : Option[Html]   = None,
+  bodyEndBlock: Option[Html]   = None
+)(contentBlock: Html
+)(implicit
+  request : RequestHeader,
+  messages: Messages
+)
+
+@govukLayout(
+  pageTitle          = title,
+  headBlock          = Some(head(customHead)),
+  beforeContentBlock = None,
+  footerBlock        = Some(hmrcStandardFooter()),
+  scriptsBlock       = Some(scripts()),
+  bodyEndBlock       = bodyEndBlock
+)(contentBlock)

--- a/app/uk/gov/hmrc/helloworldupscan/views/Scripts.scala.html
+++ b/app/uk/gov/hmrc/helloworldupscan/views/Scripts.scala.html
@@ -14,21 +14,10 @@
  * limitations under the License.
  *@
 
-@import uk.gov.hmrc.govukfrontend.views.html.components.Text
+@import views.html.helper.CSPNonce
 @import play.api.mvc.RequestHeader
 
-@this(layout: Layout)
+@this()
 
-@(
-  pageTitle: String,
-  heading  : String,
-  message  : String
-)(implicit
-  request : RequestHeader,
-  messages: Messages
-)
-
-@layout(pageTitle = Some(pageTitle)) {
-    <h1 class="govuk-heading-xl">@{Text(heading).asHtml}</h1>
-    <p class="govuk-body">@{Text(message).asHtml}</p>
-}
+@()(implicit request: RequestHeader)
+<script @CSPNonce.attr src='@controllers.routes.Assets.versioned("lib/govuk-frontend/govuk/all.js")'></script>

--- a/app/uk/gov/hmrc/helloworldupscan/views/SubmissionForm.scala.html
+++ b/app/uk/gov/hmrc/helloworldupscan/views/SubmissionForm.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,13 +17,14 @@
 @import helper._
 @import uk.gov.hmrc.helloworldupscan.config.AppConfig
 @import uk.gov.hmrc.helloworldupscan.model._
+@import play.api.mvc.RequestHeader
 
 @this(mainLayout: MainTemplate)
 
-@(form: Form[_], uploadedFile: UploadedSuccessfully)(implicit request: Request[_], messages: Messages, appConfig: AppConfig, requestHeader: RequestHeader)
+@(form: Form[_], uploadedFile: UploadedSuccessfully)(implicit request: RequestHeader, messages: Messages, appConfig: AppConfig)
 
-@mainLayout(title = "Hello from hello-world-upscan", bodyClasses = None) {
-    <h1>Please fill in additional information</h1>
+@mainLayout(title = Some("Hello from hello-world-upscan")) {
+    <h1 class="govuk-heading-l">Please fill in additional information</h1>
 
     <form action="@uk.gov.hmrc.helloworldupscan.controllers.routes.UploadFormController.submitFormWithFile" method="post">
         @CSRF.formField
@@ -31,16 +32,16 @@
         <input type="hidden" name="uploadedFileId" value="@form.data("uploadedFileId")"/>
 
         @components.InputText(
-        field = form("field1"),
-        label = "Field1"
+            field = form("field1"),
+            label = "Field1"
         )
 
         @components.InputText(
-        field = form("field2"),
-        label = "Field2"
+            field = form("field2"),
+            label = "Field2"
         )
 
-       <div>Included file: @uploadedFile.name</div>
+       <div class="govuk-body">Included file: @uploadedFile.name</div>
 
         @components.SubmitButton()
     </form>

--- a/app/uk/gov/hmrc/helloworldupscan/views/SubmissionResult.scala.html
+++ b/app/uk/gov/hmrc/helloworldupscan/views/SubmissionResult.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,11 +15,12 @@
  *@
 
 @import uk.gov.hmrc.helloworldupscan.config.AppConfig
+@import play.api.mvc.RequestHeader
 
 @this(mainLayout: MainTemplate)
 
-@()(implicit messages: Messages, appConfig: AppConfig, requestHeader: RequestHeader)
+@()(implicit messages: Messages, appConfig: AppConfig, request : RequestHeader)
 
-@mainLayout(title = "Your form has been submitted successfully", bodyClasses = None) {
-    <h1>Your form has been submitted successfully</h1>
+@mainLayout(title = Some("Your form has been submitted successfully")) {
+    <h1 class="govuk-heading-l">Your form has been submitted successfully</h1>
 }

--- a/app/uk/gov/hmrc/helloworldupscan/views/UploadForm.scala.html
+++ b/app/uk/gov/hmrc/helloworldupscan/views/UploadForm.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,13 +16,14 @@
 
 @import uk.gov.hmrc.helloworldupscan.config.AppConfig
 @import uk.gov.hmrc.upscan.services._
+@import play.api.mvc.RequestHeader
 
 @this(mainLayout: MainTemplate)
 
-@(upscanInitiateResponse : UpscanInitiateResponse)(implicit messages: Messages, appConfig: AppConfig, requestHeader: RequestHeader)
+@(upscanInitiateResponse : UpscanInitiateResponse)(implicit messages: Messages, appConfig: AppConfig, request : RequestHeader)
 
-@mainLayout(title = "Please upload a file", bodyClasses = None) {
-    <h1>Please upload the file</h1>
+@mainLayout(title = Some("Please upload a file")) {
+    <h1 class="govuk-heading-l">Please upload the file</h1>
 
     <form action="@upscanInitiateResponse.postTarget" method="post" enctype="multipart/form-data">
 
@@ -32,24 +33,23 @@
 
         <div class="js-visible mt-3">
 
-            <div class="form-group">
-                <label class="form-label" for="file-input">
+            <div class="govuk-form-group">
+                <label class="govuk-label" for="file-input">
                     <span class="">File to upload</span>
                 </label>
-                <div class="form-control-wrapper">
-                    <input
-                            type="file"
-                            id="file-input"
-                            name="file"
-                            accept=".pdf,.doc,.docx,.xlsx,.xls,.png,.jpeg,.jpg,.txt"
-                    />
-                </div>
+                <input
+                        type="file"
+                        id="file-input"
+                        name="file"
+                        class="govuk-file-upload"
+                        accept=".pdf,.doc,.docx,.xlsx,.xls,.png,.jpeg,.jpg,.txt"
+                />
             </div>
 
         </div>
 
         <div class="section">
-            <button id="submit" class="button"> Upload </button>
+            <button id="submit" class="govuk-button"> Upload </button>
         </div>
     </form>
 }

--- a/app/uk/gov/hmrc/helloworldupscan/views/UploadResult.scala.html
+++ b/app/uk/gov/hmrc/helloworldupscan/views/UploadResult.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,41 +16,44 @@
 
 @import uk.gov.hmrc.helloworldupscan.config.AppConfig
 @import uk.gov.hmrc.helloworldupscan.model._
+@import play.api.mvc.RequestHeader
 
 @this(mainLayout: MainTemplate)
 
-@(uploadId: UploadId, status : UploadStatus)(implicit messages: Messages, appConfig: AppConfig, requestHeader: RequestHeader)
+@(uploadId: UploadId, status : UploadStatus)(implicit messages: Messages, appConfig: AppConfig, request: RequestHeader)
 
 @refreshHeader = {
  <meta http-equiv="refresh" content="1"/>
 }
 
-@mainLayout(title = "Verifying uploaded file", bodyClasses = None, customHead = {
+@mainLayout(title = Some("Verifying uploaded file"), customHead = {
 status match {
 case InProgress => Some(refreshHeader)
 case _ => None
 }
 }) {
-    <h1>Verifying uploaded file</h1>
+    <h1 class="govuk-heading-l">Verifying uploaded file</h1>
 
-    @status match {
-     case InProgress => { Waiting for the file to be scanned }
-     case s : UploadedSuccessfully => { Upload of <b>@s.name</b> successful! }
-     case Failed => { File has been rejected. }
-    }
+    <p class="govuk-body">
+        @status match {
+        case InProgress => { Waiting for the file to be scanned }
+        case s : UploadedSuccessfully => { Upload of <b>@s.name</b> successful! }
+        case Failed => { File has been rejected. }
+        }
+    </p>
 
     @status match {
         case s : UploadedSuccessfully => {
-            <div class="section">
+            <p class="govuk-body">
                 <a href="@uk.gov.hmrc.helloworldupscan.controllers.routes.UploadFormController.showSubmissionForm(uploadId)">
-                    <button class="button">Next</button>
+                    <button class="govuk-button govuk-button--secondary">Next</button>
                 </a>
-            </div>
+            </p>
         }
         case _ => {
-            <div class="section">
-                <button class="button" disabled="disabled">Next</button>
-            </div>
+            <p class="govuk-body">
+                <button class="govuk-button govuk-button--secondary" disabled="disabled">Next</button>
+            </p>
         }
     }
 }

--- a/app/uk/gov/hmrc/helloworldupscan/views/components/InputText.scala.html
+++ b/app/uk/gov/hmrc/helloworldupscan/views/components/InputText.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,19 +23,19 @@
         maxlength: Int = 1000
 )(implicit messages: Messages)
 
-<div class="form-group @if(field.hasErrors){form-group-error}">
-    <label class="form-label" for="@{field.id}">
+<div class="govuk-form-group @if(field.hasErrors){govuk-form-group--error}">
+    <label class="govuk-label" for="@{field.id}">
         <div class="@if(labelClass.nonEmpty){@labelClass}">@label</div>
         @if(hint.nonEmpty){
             <div class="form-hint">@hint</div>
         }
         @field.errors.map { error =>
-            <span class="error-message" id="error-message-@{field.id}-input">@messages(error.message, error.args: _*)</span>
+            <span class="govuk-error-message" id="error-message-@{field.id}-input">@messages(error.message, error.args: _*)</span>
         }
     </label>
-    <div class="form-control-wrapper">
+    <div>
         <input
-        class="form-control @inputClass"
+        class="govuk-input @inputClass"
         type="text"
         maxlength=@maxlength
         id="@{field.id}"

--- a/app/uk/gov/hmrc/helloworldupscan/views/components/SubmitButton.scala.html
+++ b/app/uk/gov/hmrc/helloworldupscan/views/components/SubmitButton.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 @(label: Option[String] = None)(implicit messages: Messages)
 
 <div class="section">
-    <button id="submit" class="button">
+    <button id="submit" class="govuk-button">
         @if(label.nonEmpty) {
             @label
         } else {

--- a/app/uk/gov/hmrc/upscan/services/Upscan.scala
+++ b/app/uk/gov/hmrc/upscan/services/Upscan.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/build.sbt
+++ b/build.sbt
@@ -4,10 +4,10 @@ lazy val microservice = Project("hello-world-upscan", file("."))
   .enablePlugins(play.sbt.PlayScala, SbtDistributablesPlugin)
   .disablePlugins(JUnitXmlReportPlugin) //Required to prevent https://github.com/scalatest/scalatest/issues/1427
   .settings(
-    majorVersion := 0,
-    scalaVersion := "2.12.14",
+    majorVersion         := 0,
+    scalaVersion         := "2.13.8",
     libraryDependencies  ++= AppDependencies.compile ++ AppDependencies.test,
-    scalacOptions += "-target:jvm-1.8"
+    scalacOptions        += "-Wconf:cat=unused-imports&src=html/.*:s",
+    scalacOptions        += "-Wconf:src=routes/.*:s"
   )
-  .settings(SbtDistributablesPlugin.publishingSettings: _*)
   .settings(resolvers += Resolver.jcenterRepo)

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -1,4 +1,5 @@
 # microservice specific routes
+GET        /assets/*file                       controllers.Assets.versioned(path = "/public", file: Asset)
 GET        /hello-world                        uk.gov.hmrc.helloworldupscan.controllers.UploadFormController.show
 GET        /v2/hello-world                     uk.gov.hmrc.helloworldupscan.controllers.UploadFormController.showV2
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -1,4 +1,4 @@
-# Copyright 2022 HM Revenue & Customs
+# Copyright 2023 HM Revenue & Customs
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,24 +17,7 @@ include "frontend.conf"
 appName="hello-world-upscan"
 play.http.router=prod.Routes
 
-# An ApplicationLoader that uses Guice to bootstrap the application.
-play.application.loader = "uk.gov.hmrc.play.bootstrap.ApplicationLoader"
-
-# Primary entry point for all HTTP requests on Play applications
-play.http.requestHandler = "uk.gov.hmrc.play.bootstrap.http.RequestHandler"
-
-# Provides an implementation of AuditConnector. Use `uk.gov.hmrc.play.bootstrap.AuditModule` or create your own.
-# An audit connector must be provided.
-play.modules.enabled += "uk.gov.hmrc.play.audit.AuditModule"
-
 play.modules.enabled += "uk.gov.hmrc.mongo.play.PlayMongoModule"
-
-# Provides an implementation of MetricsFilter. Use `uk.gov.hmrc.play.bootstrap.graphite.GraphiteMetricsModule` or create your own.
-# A metric filter must be provided
-play.modules.enabled += "uk.gov.hmrc.play.bootstrap.graphite.GraphiteMetricsModule"
-
-# Provides an implementation and configures all filters required by a Platform frontend microservice.
-play.modules.enabled += "uk.gov.hmrc.play.bootstrap.frontend.FrontendModule"
 
 # Default http client
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.HttpClientModule"
@@ -58,15 +41,6 @@ play.filters.csp.directives.default-src = "'self' 'unsafe-inline' localhost:9000
 # play.crypto.secret="B4iYpurbzH6y3ysfFnovo1DOQVW7yT1FgjisR9Gnnz6RcTo4iCACnhtm45311gru"
 
 microservice {
-    metrics {
-        graphite {
-            host = localhost
-            port = 2003
-            prefix = play.${appName}.
-            enabled = true
-        }
-    }
-
     services {
       upscan-initiate {
           host = localhost
@@ -82,18 +56,8 @@ upscan {
   callback-endpoint = "http://localhost:9000/hello-world-upscan/hello-world/upscan-callback"
 }
 
-metrics {
-    name = ${appName}
-    rateUnit = SECONDS
-    durationUnit = SECONDS
-    showSamples = true
-    jvm = true
-    enabled = false
-}
-
 auditing {
   enabled=false
-  traceRequests=true
   consumer {
     baseUri {
       host = localhost
@@ -107,12 +71,6 @@ google-analytics {
   host=auto
 }
 
-assets {
-  version = "3.11.0"
-  version = ${?ASSETS_FRONTEND_VERSION}
-  url = "http://localhost:9032/assets/"
-}
-
 contact-frontend {
   host = "http://localhost:9250"
 }
@@ -120,3 +78,5 @@ contact-frontend {
 mongodb {
   uri = "mongodb://localhost:27017/hello-world-upscan"
 }
+
+contact-frontend.serviceId = "hello-world-upscan"

--- a/conf/messages
+++ b/conf/messages
@@ -1,1 +1,3 @@
+service.name = hello-world-upscan
+service.homePageUrl = /hello-world-upscan/hello-world
 site.continue = Continue

--- a/conf/prod.routes
+++ b/conf/prod.routes
@@ -1,6 +1,5 @@
 # Add all the application routes to the app.routes file
 ->         /hello-world-upscan        app.Routes
 ->         /                          health.Routes
-->     	   /template                  template.Routes
 
 GET        /admin/metrics             com.kenshoo.play.metrics.MetricsController.metrics

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -3,12 +3,11 @@ import sbt._
 
 object AppDependencies {
 
-  val bootstrapVersion = "7.11.0"
+  val bootstrapVersion = "7.15.0"
   val hmrcMongoVersion = "0.73.0"
 
   val compile = Seq(
-    "uk.gov.hmrc"             %% "govuk-template"              % "5.78.0-play-28",
-    "uk.gov.hmrc"             %% "play-ui"                     % "9.11.0-play-28",
+    "uk.gov.hmrc"             %% "play-frontend-hmrc"          % "7.3.0-play-28",
     "uk.gov.hmrc"             %% "bootstrap-frontend-play-28"  % bootstrapVersion,
     "uk.gov.hmrc.mongo"       %% "hmrc-mongo-play-28"          % hmrcMongoVersion
   )

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.6.2
+sbt.version=1.7.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,6 +3,7 @@ resolvers += Resolver.url("HMRC-open-artefacts-ivy2", url("https://open.artefact
   Resolver.ivyStylePatterns)
 resolvers += Resolver.typesafeRepo("releases")
 
-addSbtPlugin("uk.gov.hmrc"       % "sbt-auto-build"     % "3.8.0")
-addSbtPlugin("uk.gov.hmrc"       % "sbt-distributables" % "2.1.0")
-addSbtPlugin("com.typesafe.play" % "sbt-plugin"         % "2.8.18")
+addSbtPlugin("uk.gov.hmrc"       % "sbt-auto-build"     % "3.9.0")
+addSbtPlugin("uk.gov.hmrc"       % "sbt-distributables" % "2.2.0")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin"         % "2.8.19")
+addSbtPlugin("org.irundaia.sbt"  % "sbt-sassify"        % "1.5.1" )

--- a/test/uk/gov/hmrc/helloworldupscan/controllers/CallbackBodyTest.scala
+++ b/test/uk/gov/hmrc/helloworldupscan/controllers/CallbackBodyTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/helloworldupscan/repository/UserSessionRepositoryTest.scala
+++ b/test/uk/gov/hmrc/helloworldupscan/repository/UserSessionRepositoryTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/helloworldupscan/services/MongoBackedUploadProgressTrackerSpec.scala
+++ b/test/uk/gov/hmrc/helloworldupscan/services/MongoBackedUploadProgressTrackerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
This also includes ditching the `plat-ui` dependency for the `play-frontend-hmrc` one, which means rewriting existing pages.

To ease this task, the changes are based on some of our  recently updated frontend services.
I've compared the local version with the qa one and seem to be pretty much identical, meaning that the functionality is the same but the style differs minimally.